### PR TITLE
[RP-1760] add Conversions API client

### DIFF
--- a/.github/workflows/build-and-integration-test.yml
+++ b/.github/workflows/build-and-integration-test.yml
@@ -40,4 +40,5 @@ jobs:
           RYFT_NON_HOSTED_ACCOUNT_ID: ${{ secrets.RYFT_NON_HOSTED_ACCOUNT_ID }}
           RYFT_PAYMENT_METHOD_ID: ${{ secrets.RYFT_PAYMENT_METHOD_ID }}
           RYFT_PLATFORM_FEE_ID: ${{ secrets.RYFT_PLATFORM_FEE_ID }}
+          RYFT_CONVERSION_ACCOUNT_ID: ${{ secrets.RYFT_CONVERSION_ACCOUNT_ID }}
         run: ./integration-test.sh

--- a/.github/workflows/build-and-integration-test.yml
+++ b/.github/workflows/build-and-integration-test.yml
@@ -40,5 +40,4 @@ jobs:
           RYFT_NON_HOSTED_ACCOUNT_ID: ${{ secrets.RYFT_NON_HOSTED_ACCOUNT_ID }}
           RYFT_PAYMENT_METHOD_ID: ${{ secrets.RYFT_PAYMENT_METHOD_ID }}
           RYFT_PLATFORM_FEE_ID: ${{ secrets.RYFT_PLATFORM_FEE_ID }}
-          RYFT_CONVERSION_ACCOUNT_ID: ${{ secrets.RYFT_CONVERSION_ACCOUNT_ID }}
         run: ./integration-test.sh

--- a/RyftDotNet/src/RyftDotNet/Client/Error/RyftApiException.cs
+++ b/RyftDotNet/src/RyftDotNet/Client/Error/RyftApiException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Net;
 
 namespace RyftDotNet.Client.Error
@@ -15,10 +16,19 @@ namespace RyftDotNet.Client.Error
             : base(message, innerException) { }
 
         public RyftApiException(RyftApiErrorResponse? apiError, HttpStatusCode httpStatusCode)
-            : base(message: $"Received an unsuccessful status code ({httpStatusCode}) from the API")
+            : base(message: BuildMessage(apiError, httpStatusCode))
         {
             ApiError = apiError;
             HttpStatusCode = httpStatusCode;
+        }
+
+        private static string BuildMessage(RyftApiErrorResponse? apiError, HttpStatusCode httpStatusCode)
+        {
+            var baseMessage = $"Received an unsuccessful status code ({httpStatusCode}) from the API";
+            var errorDetail = apiError?.Errors?.Select(e => $"{e.Code}: {e.Message}").ToList();
+            return errorDetail != null && errorDetail.Count > 0
+                ? $"{baseMessage} - {string.Join("; ", errorDetail)}"
+                : baseMessage;
         }
     }
 }

--- a/RyftDotNet/src/RyftDotNet/Conversions/Conversion.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/Conversion.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace RyftDotNet.Conversions
+{
+    public sealed class Conversion : IEquatable<Conversion>
+    {
+        [property: JsonPropertyName("id")]
+        public string Id { get; }
+
+        [property: JsonPropertyName("sell")]
+        public ConversionSell Sell { get; }
+
+        [property: JsonPropertyName("buy")]
+        public ConversionBuy Buy { get; }
+
+        [property: JsonPropertyName("rate")]
+        public decimal? Rate { get; }
+
+        [property: JsonPropertyName("status")]
+        public ConversionStatus Status { get; }
+
+        [property: JsonPropertyName("reason")]
+        public string? Reason { get; }
+
+        [property: JsonPropertyName("estimatedSettlementDate")]
+        public string? EstimatedSettlementDate { get; }
+
+        [property: JsonPropertyName("settledTimestamp")]
+        public long? SettledTimestamp { get; }
+
+        [property: JsonPropertyName("createdBy")]
+        public ConversionCreatedBy? CreatedBy { get; }
+
+        [property: JsonPropertyName("createdTimestamp")]
+        public long CreatedTimestamp { get; }
+
+        public Conversion(
+            string id,
+            ConversionSell sell,
+            ConversionBuy buy,
+            decimal? rate,
+            ConversionStatus status,
+            string? reason,
+            string? estimatedSettlementDate,
+            long? settledTimestamp,
+            ConversionCreatedBy? createdBy,
+            long createdTimestamp)
+        {
+            Id = id;
+            Sell = sell;
+            Buy = buy;
+            Rate = rate;
+            Status = status;
+            Reason = reason;
+            EstimatedSettlementDate = estimatedSettlementDate;
+            SettledTimestamp = settledTimestamp;
+            CreatedBy = createdBy;
+            CreatedTimestamp = createdTimestamp;
+        }
+
+        public bool Equals(Conversion? other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return Id == other.Id && Sell.Equals(other.Sell)
+                                  && Buy.Equals(other.Buy)
+                                  && Rate == other.Rate
+                                  && Status == other.Status
+                                  && Reason == other.Reason
+                                  && EstimatedSettlementDate == other.EstimatedSettlementDate
+                                  && SettledTimestamp == other.SettledTimestamp
+                                  && Equals(CreatedBy, other.CreatedBy)
+                                  && CreatedTimestamp == other.CreatedTimestamp;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return ReferenceEquals(this, obj) || obj is Conversion other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = new HashCode();
+            hashCode.Add(Id);
+            hashCode.Add(Sell);
+            hashCode.Add(Buy);
+            hashCode.Add(Rate);
+            hashCode.Add((int)Status);
+            hashCode.Add(Reason);
+            hashCode.Add(EstimatedSettlementDate);
+            hashCode.Add(SettledTimestamp);
+            hashCode.Add(CreatedBy);
+            hashCode.Add(CreatedTimestamp);
+            return hashCode.ToHashCode();
+        }
+    }
+}

--- a/RyftDotNet/src/RyftDotNet/Conversions/Conversion.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/Conversion.cs
@@ -94,7 +94,7 @@ namespace RyftDotNet.Conversions
             hashCode.Add(Sell);
             hashCode.Add(Buy);
             hashCode.Add(Rate);
-            hashCode.Add((int)Status);
+            hashCode.Add(Status);
             hashCode.Add(Reason);
             hashCode.Add(EstimatedSettlementDate);
             hashCode.Add(SettledTimestamp);

--- a/RyftDotNet/src/RyftDotNet/Conversions/Conversion.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/Conversion.cs
@@ -59,33 +59,20 @@ namespace RyftDotNet.Conversions
             CreatedTimestamp = createdTimestamp;
         }
 
-        public bool Equals(Conversion? other)
-        {
-            if (other is null)
-            {
-                return false;
-            }
+        public bool Equals(Conversion? other) =>
+            !(other is null) && (ReferenceEquals(this, other) || Id == other.Id
+                && Sell.Equals(other.Sell)
+                && Buy.Equals(other.Buy)
+                && Rate == other.Rate
+                && Status == other.Status
+                && Reason == other.Reason
+                && EstimatedSettlementDate == other.EstimatedSettlementDate
+                && SettledTimestamp == other.SettledTimestamp
+                && Equals(CreatedBy, other.CreatedBy)
+                && CreatedTimestamp == other.CreatedTimestamp);
 
-            if (ReferenceEquals(this, other))
-            {
-                return true;
-            }
-
-            return Id == other.Id && Sell.Equals(other.Sell)
-                                  && Buy.Equals(other.Buy)
-                                  && Rate == other.Rate
-                                  && Status == other.Status
-                                  && Reason == other.Reason
-                                  && EstimatedSettlementDate == other.EstimatedSettlementDate
-                                  && SettledTimestamp == other.SettledTimestamp
-                                  && Equals(CreatedBy, other.CreatedBy)
-                                  && CreatedTimestamp == other.CreatedTimestamp;
-        }
-
-        public override bool Equals(object? obj)
-        {
-            return ReferenceEquals(this, obj) || obj is Conversion other && Equals(other);
-        }
+        public override bool Equals(object? obj) =>
+            ReferenceEquals(this, obj) || obj is Conversion other && Equals(other);
 
         public override int GetHashCode()
         {

--- a/RyftDotNet/src/RyftDotNet/Conversions/ConversionApiClient.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/ConversionApiClient.cs
@@ -19,7 +19,6 @@ namespace RyftDotNet.Conversions
         }
 
         public Task<Conversion> CreateAsync(
-            string accountId,
             CreateConversionRequest request,
             ClientRequestSettings? requestSettings = null,
             CancellationToken cancellationToken = default)
@@ -32,7 +31,6 @@ namespace RyftDotNet.Conversions
             );
 
         public Task<Conversion> GetAsync(
-            string accountId,
             string id,
             ClientRequestSettings? requestSettings = null,
             CancellationToken cancellationToken = default)
@@ -56,7 +54,7 @@ namespace RyftDotNet.Conversions
                 cancellationToken: cancellationToken
             );
 
-        public Task<ConversionRate> GetRates(
+        public Task<ConversionRate> GetRatesAsync(
             GetRateRequest? request = null,
             ClientRequestSettings? requestSettings = null,
             CancellationToken cancellationToken = default)

--- a/RyftDotNet/src/RyftDotNet/Conversions/ConversionApiClient.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/ConversionApiClient.cs
@@ -9,14 +9,11 @@ namespace RyftDotNet.Conversions
 {
     public sealed class ConversionApiClient : IConversionApiClient
     {
-        private const string MoneyMovementApiSuffix = "conversions";
+        private const string ConversionsApiSuffix = "conversions";
 
         private readonly IRyftApiClient apiClient;
 
-        public ConversionApiClient(IRyftApiClient apiClient)
-        {
-            this.apiClient = apiClient;
-        }
+        public ConversionApiClient(IRyftApiClient apiClient) => this.apiClient = apiClient;
 
         public Task<Conversion> CreateAsync(
             CreateConversionRequest request,
@@ -54,7 +51,7 @@ namespace RyftDotNet.Conversions
                 cancellationToken: cancellationToken
             );
 
-        public Task<ConversionRate> GetRatesAsync(
+        public Task<ConversionRate> GetRateAsync(
             GetRateRequest? request = null,
             ClientRequestSettings? requestSettings = null,
             CancellationToken cancellationToken = default)
@@ -67,6 +64,6 @@ namespace RyftDotNet.Conversions
             );
 
         private static string ResourcePath() =>
-            string.Join("/", MoneyMovementApiSuffix);
+            string.Join("/", ConversionsApiSuffix);
     }
 }

--- a/RyftDotNet/src/RyftDotNet/Conversions/ConversionApiClient.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/ConversionApiClient.cs
@@ -1,0 +1,74 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using RyftDotNet.Client;
+using RyftDotNet.Common;
+using RyftDotNet.Conversions.Request;
+
+namespace RyftDotNet.Conversions
+{
+    public sealed class ConversionApiClient : IConversionApiClient
+    {
+        private const string MoneyMovementApiSuffix = "conversions";
+
+        private readonly IRyftApiClient apiClient;
+
+        public ConversionApiClient(IRyftApiClient apiClient)
+        {
+            this.apiClient = apiClient;
+        }
+
+        public Task<Conversion> CreateAsync(
+            string accountId,
+            CreateConversionRequest request,
+            ClientRequestSettings? requestSettings = null,
+            CancellationToken cancellationToken = default)
+            => apiClient.RequestAsync<Conversion>(
+                path: $"{ResourcePath()}",
+                HttpMethod.Post,
+                request,
+                requestSettings,
+                cancellationToken: cancellationToken
+            );
+
+        public Task<Conversion> GetAsync(
+            string accountId,
+            string id,
+            ClientRequestSettings? requestSettings = null,
+            CancellationToken cancellationToken = default)
+            => apiClient.RequestAsync<Conversion>(
+                path: $"{ResourcePath()}/{id}",
+                HttpMethod.Get,
+                requestBody: null,
+                requestSettings,
+                cancellationToken: cancellationToken
+            );
+
+        public Task<PaginatedResponse<Conversion>> ListAsync(
+            ListConversionsRequest? request = null,
+            ClientRequestSettings? requestSettings = null,
+            CancellationToken cancellationToken = default)
+            => apiClient.RequestAsync<PaginatedResponse<Conversion>>(
+                path: $"{ResourcePath()}{request?.ToQueryString()}",
+                HttpMethod.Get,
+                requestBody: null,
+                requestSettings,
+                cancellationToken: cancellationToken
+            );
+
+        public Task<ConversionRate> GetRates(
+            GetRateRequest? request = null,
+            ClientRequestSettings? requestSettings = null,
+            CancellationToken cancellationToken = default)
+            => apiClient.RequestAsync<ConversionRate>(
+                path: $"{ResourcePath()}/rate{request?.ToQueryString()}",
+                HttpMethod.Get,
+                requestBody: null,
+                requestSettings,
+                cancellationToken: cancellationToken
+            );
+
+        private static string ResourcePath() =>
+            string.Join("/", MoneyMovementApiSuffix);
+    }
+}

--- a/RyftDotNet/src/RyftDotNet/Conversions/ConversionBuy.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/ConversionBuy.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace RyftDotNet.Conversions
+{
+    public sealed class ConversionBuy : IEquatable<ConversionBuy>
+    {
+        [property: JsonPropertyName("amount")]
+        public long? Amount { get; }
+
+        [property: JsonPropertyName("currency")]
+        public string Currency { get; }
+
+        [property: JsonPropertyName("fees")]
+        public ConversionFees? Fees { get; }
+
+        public ConversionBuy(long? amount, string currency, ConversionFees? fees)
+        {
+            Amount = amount;
+            Currency = currency;
+            Fees = fees;
+        }
+
+        public bool Equals(ConversionBuy? other)
+            => !ReferenceEquals(null, other)
+               && (ReferenceEquals(this, other)
+                   || Amount == other.Amount
+                   && Currency == other.Currency
+                   && Equals(Fees, other.Fees));
+
+        public override bool Equals(object? obj)
+            => obj is ConversionBuy other && Equals(other);
+
+        public override int GetHashCode()
+            => HashCode.Combine(Amount, Currency, Fees);
+    }
+}

--- a/RyftDotNet/src/RyftDotNet/Conversions/ConversionCreatedBy.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/ConversionCreatedBy.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace RyftDotNet.Conversions
+{
+    public sealed class ConversionCreatedBy : IEquatable<ConversionCreatedBy>
+    {
+        [property: JsonPropertyName("id")]
+        public string Id { get; }
+
+        [property: JsonPropertyName("name")]
+        public string? Name { get; }
+
+        public ConversionCreatedBy(string id, string? name)
+        {
+            Id = id;
+            Name = name;
+        }
+
+        public bool Equals(ConversionCreatedBy? other)
+            => !ReferenceEquals(null, other)
+               && (ReferenceEquals(this, other)
+                   || Id == other.Id
+                   && Name == other.Name);
+
+        public override bool Equals(object? obj)
+            => obj is ConversionCreatedBy other && Equals(other);
+
+        public override int GetHashCode()
+            => HashCode.Combine(Id, Name);
+    }
+}

--- a/RyftDotNet/src/RyftDotNet/Conversions/ConversionFee.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/ConversionFee.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace RyftDotNet.Conversions
+{
+    public sealed class ConversionFee : IEquatable<ConversionFee>
+    {
+        [property: JsonPropertyName("amount")]
+        public long Amount { get; }
+
+        public ConversionFee(long amount)
+        {
+            Amount = amount;
+        }
+
+        public bool Equals(ConversionFee? other)
+            => !ReferenceEquals(null, other)
+               && (ReferenceEquals(this, other)
+                   || Amount == other.Amount);
+
+        public override bool Equals(object? obj)
+            => obj is ConversionFee other && Equals(other);
+
+        public override int GetHashCode()
+            => HashCode.Combine(Amount);
+    }
+}

--- a/RyftDotNet/src/RyftDotNet/Conversions/ConversionFees.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/ConversionFees.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace RyftDotNet.Conversions
+{
+    public sealed class ConversionFees : IEquatable<ConversionFees>
+    {
+        [property: JsonPropertyName("ryft")]
+        public ConversionFee? Ryft { get; }
+
+        [property: JsonPropertyName("platform")]
+        public ConversionPlatformFeeDetail? Platform { get; }
+
+        public ConversionFees(ConversionFee? ryft, ConversionPlatformFeeDetail? platform)
+        {
+            Ryft = ryft;
+            Platform = platform;
+        }
+
+        public bool Equals(ConversionFees? other)
+            => !ReferenceEquals(null, other)
+               && (ReferenceEquals(this, other)
+                   || Equals(Ryft, other.Ryft)
+                   && Equals(Platform, other.Platform));
+
+        public override bool Equals(object? obj)
+            => obj is ConversionFees other && Equals(other);
+
+        public override int GetHashCode()
+            => HashCode.Combine(Ryft, Platform);
+    }
+}

--- a/RyftDotNet/src/RyftDotNet/Conversions/ConversionPlatformFeeDetail.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/ConversionPlatformFeeDetail.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace RyftDotNet.Conversions
+{
+    public sealed class ConversionPlatformFeeDetail : IEquatable<ConversionPlatformFeeDetail>
+    {
+        [property: JsonPropertyName("amount")]
+        public long Amount { get; }
+
+        [property: JsonPropertyName("ryftFee")]
+        public ConversionFee RyftFee { get; }
+
+        public ConversionPlatformFeeDetail(long amount, ConversionFee ryftFee)
+        {
+            Amount = amount;
+            RyftFee = ryftFee;
+        }
+
+        public bool Equals(ConversionPlatformFeeDetail? other)
+            => !ReferenceEquals(null, other)
+               && (ReferenceEquals(this, other)
+                   || Amount == other.Amount
+                   && Equals(RyftFee, other.RyftFee));
+
+        public override bool Equals(object? obj)
+            => obj is ConversionPlatformFeeDetail other && Equals(other);
+
+        public override int GetHashCode()
+            => HashCode.Combine(Amount, RyftFee);
+    }
+}

--- a/RyftDotNet/src/RyftDotNet/Conversions/ConversionRate.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/ConversionRate.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace RyftDotNet.Conversions
+{
+    public sealed class ConversionRate : IEquatable<ConversionRate>
+    {
+        [property: JsonPropertyName("sell")]
+        public ConversionRateSell Sell { get; }
+
+        [property: JsonPropertyName("buy")]
+        public ConversionRateBuy Buy { get; }
+
+        [property: JsonPropertyName("rate")]
+        public decimal Rate { get; }
+
+        [property: JsonPropertyName("estimatedSettlementDate")]
+        public string? EstimatedSettlementDate { get; }
+
+        public ConversionRate(
+            ConversionRateSell sell,
+            ConversionRateBuy buy,
+            decimal rate,
+            string? estimatedSettlementDate)
+        {
+            Sell = sell;
+            Buy = buy;
+            Rate = rate;
+            EstimatedSettlementDate = estimatedSettlementDate;
+        }
+
+        public bool Equals(ConversionRate? other)
+            => !ReferenceEquals(null, other)
+               && (ReferenceEquals(this, other)
+                   || Sell.Equals(other.Sell)
+                   && Buy.Equals(other.Buy)
+                   && Rate == other.Rate
+                   && EstimatedSettlementDate == other.EstimatedSettlementDate);
+
+        public override bool Equals(object? obj)
+            => obj is ConversionRate other && Equals(other);
+
+        public override int GetHashCode()
+            => HashCode.Combine(Sell, Buy, Rate, EstimatedSettlementDate);
+    }
+}

--- a/RyftDotNet/src/RyftDotNet/Conversions/ConversionRateBuy.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/ConversionRateBuy.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace RyftDotNet.Conversions
+{
+    public sealed class ConversionRateBuy : IEquatable<ConversionRateBuy>
+    {
+        [property: JsonPropertyName("amount")]
+        public long Amount { get; }
+
+        [property: JsonPropertyName("currency")]
+        public string Currency { get; }
+
+        [property: JsonPropertyName("fees")]
+        public ConversionFees Fees { get; }
+
+        public ConversionRateBuy(long amount, string currency, ConversionFees fees)
+        {
+            Amount = amount;
+            Currency = currency;
+            Fees = fees;
+        }
+
+        public bool Equals(ConversionRateBuy? other)
+            => !ReferenceEquals(null, other)
+               && (ReferenceEquals(this, other)
+                   || Amount == other.Amount
+                   && Currency == other.Currency
+                   && Fees.Equals(other.Fees));
+
+        public override bool Equals(object? obj)
+            => obj is ConversionRateBuy other && Equals(other);
+
+        public override int GetHashCode()
+            => HashCode.Combine(Amount, Currency, Fees);
+    }
+}

--- a/RyftDotNet/src/RyftDotNet/Conversions/ConversionRateBuy.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/ConversionRateBuy.cs
@@ -12,9 +12,9 @@ namespace RyftDotNet.Conversions
         public string Currency { get; }
 
         [property: JsonPropertyName("fees")]
-        public ConversionFees Fees { get; }
+        public ConversionFees? Fees { get; }
 
-        public ConversionRateBuy(long amount, string currency, ConversionFees fees)
+        public ConversionRateBuy(long amount, string currency, ConversionFees? fees)
         {
             Amount = amount;
             Currency = currency;
@@ -26,7 +26,7 @@ namespace RyftDotNet.Conversions
                && (ReferenceEquals(this, other)
                    || Amount == other.Amount
                    && Currency == other.Currency
-                   && Fees.Equals(other.Fees));
+                   && Equals(Fees, other.Fees));
 
         public override bool Equals(object? obj)
             => obj is ConversionRateBuy other && Equals(other);

--- a/RyftDotNet/src/RyftDotNet/Conversions/ConversionRateSell.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/ConversionRateSell.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace RyftDotNet.Conversions
+{
+    public sealed class ConversionRateSell : IEquatable<ConversionRateSell>
+    {
+        [property: JsonPropertyName("amount")]
+        public long Amount { get; }
+
+        [property: JsonPropertyName("currency")]
+        public string Currency { get; }
+
+        public ConversionRateSell(long amount, string currency)
+        {
+            Amount = amount;
+            Currency = currency;
+        }
+
+        public bool Equals(ConversionRateSell? other)
+            => !ReferenceEquals(null, other)
+               && (ReferenceEquals(this, other)
+                   || Amount == other.Amount
+                   && Currency == other.Currency);
+
+        public override bool Equals(object? obj)
+            => obj is ConversionRateSell other && Equals(other);
+
+        public override int GetHashCode()
+            => HashCode.Combine(Amount, Currency);
+    }
+}

--- a/RyftDotNet/src/RyftDotNet/Conversions/ConversionRateSell.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/ConversionRateSell.cs
@@ -11,22 +11,27 @@ namespace RyftDotNet.Conversions
         [property: JsonPropertyName("currency")]
         public string Currency { get; }
 
-        public ConversionRateSell(long amount, string currency)
+        [property: JsonPropertyName("fees")]
+        public ConversionFees? Fees { get; }
+
+        public ConversionRateSell(long amount, string currency, ConversionFees? fees)
         {
             Amount = amount;
             Currency = currency;
+            Fees = fees;
         }
 
         public bool Equals(ConversionRateSell? other)
             => !ReferenceEquals(null, other)
                && (ReferenceEquals(this, other)
                    || Amount == other.Amount
-                   && Currency == other.Currency);
+                   && Currency == other.Currency
+                   && Equals(Fees, other.Fees));
 
         public override bool Equals(object? obj)
             => obj is ConversionRateSell other && Equals(other);
 
         public override int GetHashCode()
-            => HashCode.Combine(Amount, Currency);
+            => HashCode.Combine(Amount, Currency, Fees);
     }
 }

--- a/RyftDotNet/src/RyftDotNet/Conversions/ConversionSell.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/ConversionSell.cs
@@ -6,27 +6,32 @@ namespace RyftDotNet.Conversions
     public sealed class ConversionSell : IEquatable<ConversionSell>
     {
         [property: JsonPropertyName("amount")]
-        public long Amount { get; }
+        public long? Amount { get; }
 
         [property: JsonPropertyName("currency")]
         public string Currency { get; }
 
-        public ConversionSell(long amount, string currency)
+        [property: JsonPropertyName("fees")]
+        public ConversionFees? Fees { get; }
+
+        public ConversionSell(long? amount, string currency, ConversionFees? fees)
         {
             Amount = amount;
             Currency = currency;
+            Fees = fees;
         }
 
         public bool Equals(ConversionSell? other)
             => !ReferenceEquals(null, other)
                && (ReferenceEquals(this, other)
                    || Amount == other.Amount
-                   && Currency == other.Currency);
+                   && Currency == other.Currency
+                   && Equals(Fees, other.Fees));
 
         public override bool Equals(object? obj)
             => obj is ConversionSell other && Equals(other);
 
         public override int GetHashCode()
-            => HashCode.Combine(Amount, Currency);
+            => HashCode.Combine(Amount, Currency, Fees);
     }
 }

--- a/RyftDotNet/src/RyftDotNet/Conversions/ConversionSell.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/ConversionSell.cs
@@ -6,12 +6,12 @@ namespace RyftDotNet.Conversions
     public sealed class ConversionSell : IEquatable<ConversionSell>
     {
         [property: JsonPropertyName("amount")]
-        public long? Amount { get; }
+        public long Amount { get; }
 
         [property: JsonPropertyName("currency")]
         public string Currency { get; }
 
-        public ConversionSell(long? amount, string currency)
+        public ConversionSell(long amount, string currency)
         {
             Amount = amount;
             Currency = currency;

--- a/RyftDotNet/src/RyftDotNet/Conversions/ConversionSell.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/ConversionSell.cs
@@ -6,7 +6,7 @@ namespace RyftDotNet.Conversions
     public sealed class ConversionSell : IEquatable<ConversionSell>
     {
         [property: JsonPropertyName("amount")]
-        public long? Amount { get; }
+        public long Amount { get; }
 
         [property: JsonPropertyName("currency")]
         public string Currency { get; }
@@ -14,7 +14,7 @@ namespace RyftDotNet.Conversions
         [property: JsonPropertyName("fees")]
         public ConversionFees? Fees { get; }
 
-        public ConversionSell(long? amount, string currency, ConversionFees? fees)
+        public ConversionSell(long amount, string currency, ConversionFees? fees)
         {
             Amount = amount;
             Currency = currency;

--- a/RyftDotNet/src/RyftDotNet/Conversions/ConversionSell.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/ConversionSell.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace RyftDotNet.Conversions
+{
+    public sealed class ConversionSell : IEquatable<ConversionSell>
+    {
+        [property: JsonPropertyName("amount")]
+        public long? Amount { get; }
+
+        [property: JsonPropertyName("currency")]
+        public string Currency { get; }
+
+        public ConversionSell(long? amount, string currency)
+        {
+            Amount = amount;
+            Currency = currency;
+        }
+
+        public bool Equals(ConversionSell? other)
+            => !ReferenceEquals(null, other)
+               && (ReferenceEquals(this, other)
+                   || Amount == other.Amount
+                   && Currency == other.Currency);
+
+        public override bool Equals(object? obj)
+            => obj is ConversionSell other && Equals(other);
+
+        public override int GetHashCode()
+            => HashCode.Combine(Amount, Currency);
+    }
+}

--- a/RyftDotNet/src/RyftDotNet/Conversions/ConversionStatus.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/ConversionStatus.cs
@@ -1,8 +1,12 @@
+using RyftDotNet.Common;
+
 namespace RyftDotNet.Conversions
 {
-    public enum ConversionStatus
+    public sealed class ConversionStatus : ConstantValue
     {
-        InProgress,
-        Settled
+        public ConversionStatus(string value) : base(value) { }
+
+        public static readonly ConversionStatus InProgress = new ConversionStatus("InProgress");
+        public static readonly ConversionStatus Settled = new ConversionStatus("Settled");
     }
 }

--- a/RyftDotNet/src/RyftDotNet/Conversions/ConversionStatus.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/ConversionStatus.cs
@@ -1,0 +1,8 @@
+namespace RyftDotNet.Conversions
+{
+    public enum ConversionStatus
+    {
+        InProgress,
+        Settled
+    }
+}

--- a/RyftDotNet/src/RyftDotNet/Conversions/IConversionApiClient.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/IConversionApiClient.cs
@@ -23,7 +23,7 @@ namespace RyftDotNet.Conversions
             ClientRequestSettings? requestSettings = null,
             CancellationToken cancellationToken = default);
 
-        Task<ConversionRate> GetRatesAsync(
+        Task<ConversionRate> GetRateAsync(
             GetRateRequest? request = null,
             ClientRequestSettings? requestSettings = null,
             CancellationToken cancellationToken = default);

--- a/RyftDotNet/src/RyftDotNet/Conversions/IConversionApiClient.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/IConversionApiClient.cs
@@ -1,0 +1,33 @@
+using System.Threading;
+using System.Threading.Tasks;
+using RyftDotNet.Client;
+using RyftDotNet.Common;
+using RyftDotNet.Conversions.Request;
+
+namespace RyftDotNet.Conversions
+{
+    public interface IConversionApiClient
+    {
+        Task<Conversion> CreateAsync(
+            string accountId,
+            CreateConversionRequest request,
+            ClientRequestSettings? requestSettings = null,
+            CancellationToken cancellationToken = default);
+
+        Task<Conversion> GetAsync(
+            string accountId,
+            string id,
+            ClientRequestSettings? requestSettings = null,
+            CancellationToken cancellationToken = default);
+
+        Task<PaginatedResponse<Conversion>> ListAsync(
+            ListConversionsRequest? request = null,
+            ClientRequestSettings? requestSettings = null,
+            CancellationToken cancellationToken = default);
+
+        Task<ConversionRate> GetRates(
+            GetRateRequest? request = null,
+            ClientRequestSettings? requestSettings = null,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/RyftDotNet/src/RyftDotNet/Conversions/IConversionApiClient.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/IConversionApiClient.cs
@@ -9,13 +9,11 @@ namespace RyftDotNet.Conversions
     public interface IConversionApiClient
     {
         Task<Conversion> CreateAsync(
-            string accountId,
             CreateConversionRequest request,
             ClientRequestSettings? requestSettings = null,
             CancellationToken cancellationToken = default);
 
         Task<Conversion> GetAsync(
-            string accountId,
             string id,
             ClientRequestSettings? requestSettings = null,
             CancellationToken cancellationToken = default);
@@ -25,7 +23,7 @@ namespace RyftDotNet.Conversions
             ClientRequestSettings? requestSettings = null,
             CancellationToken cancellationToken = default);
 
-        Task<ConversionRate> GetRates(
+        Task<ConversionRate> GetRatesAsync(
             GetRateRequest? request = null,
             ClientRequestSettings? requestSettings = null,
             CancellationToken cancellationToken = default);

--- a/RyftDotNet/src/RyftDotNet/Conversions/Request/BuyConversionRequest.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/Request/BuyConversionRequest.cs
@@ -1,12 +1,10 @@
 namespace RyftDotNet.Conversions.Request
 {
-    public sealed class ConversionSideRequest
+    public sealed class BuyConversionRequest
     {
         public string Currency { get; }
 
-        public long? Amount { get; set; }
-
-        public ConversionSideRequest(string currency)
+        public BuyConversionRequest(string currency)
         {
             Currency = currency;
         }

--- a/RyftDotNet/src/RyftDotNet/Conversions/Request/ConversionSideRequest.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/Request/ConversionSideRequest.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace RyftDotNet.Conversions.Request
+{
+    public sealed class ConversionSideRequest
+    {
+        [JsonRequired]
+        public string Currency { get; }
+
+        public long? Amount { get; set; }
+
+        public ConversionSideRequest(string currency)
+        {
+            Currency = currency;
+        }
+    }
+}

--- a/RyftDotNet/src/RyftDotNet/Conversions/Request/ConversionSideRequest.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/Request/ConversionSideRequest.cs
@@ -1,10 +1,7 @@
-using System.Text.Json.Serialization;
-
 namespace RyftDotNet.Conversions.Request
 {
     public sealed class ConversionSideRequest
     {
-        [JsonRequired]
         public string Currency { get; }
 
         public long? Amount { get; set; }

--- a/RyftDotNet/src/RyftDotNet/Conversions/Request/CreateConversionRequest.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/Request/CreateConversionRequest.cs
@@ -1,16 +1,11 @@
-using System.Text.Json.Serialization;
-
 namespace RyftDotNet.Conversions.Request
 {
     public sealed class CreateConversionRequest
     {
-        [JsonRequired]
         public ConversionSideRequest Sell { get; }
 
-        [JsonRequired]
         public ConversionSideRequest Buy { get; }
 
-        [JsonRequired]
         public bool TermAgreement { get; }
 
         public string? FixedSide { get; set; }

--- a/RyftDotNet/src/RyftDotNet/Conversions/Request/CreateConversionRequest.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/Request/CreateConversionRequest.cs
@@ -2,9 +2,9 @@ namespace RyftDotNet.Conversions.Request
 {
     public sealed class CreateConversionRequest
     {
-        public ConversionSideRequest Sell { get; }
+        public SellConversionRequest Sell { get; }
 
-        public ConversionSideRequest Buy { get; }
+        public BuyConversionRequest Buy { get; }
 
         public bool TermAgreement { get; }
 
@@ -13,8 +13,8 @@ namespace RyftDotNet.Conversions.Request
         public string? Reason { get; set; }
 
         public CreateConversionRequest(
-            ConversionSideRequest sell,
-            ConversionSideRequest buy,
+            SellConversionRequest sell,
+            BuyConversionRequest buy,
             bool termAgreement)
         {
             Sell = sell;

--- a/RyftDotNet/src/RyftDotNet/Conversions/Request/CreateConversionRequest.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/Request/CreateConversionRequest.cs
@@ -8,8 +8,6 @@ namespace RyftDotNet.Conversions.Request
 
         public bool TermAgreement { get; }
 
-        public string? FixedSide { get; set; }
-
         public string? Reason { get; set; }
 
         public CreateConversionRequest(

--- a/RyftDotNet/src/RyftDotNet/Conversions/Request/CreateConversionRequest.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/Request/CreateConversionRequest.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace RyftDotNet.Conversions.Request
+{
+    public sealed class CreateConversionRequest
+    {
+        [JsonRequired]
+        public ConversionSideRequest Sell { get; }
+
+        [JsonRequired]
+        public ConversionSideRequest Buy { get; }
+
+        [JsonRequired]
+        public bool TermAgreement { get; }
+
+        public string? FixedSide { get; set; }
+
+        public string? Reason { get; set; }
+
+        public CreateConversionRequest(
+            ConversionSideRequest sell,
+            ConversionSideRequest buy,
+            bool termAgreement)
+        {
+            Sell = sell;
+            Buy = buy;
+            TermAgreement = termAgreement;
+        }
+    }
+}

--- a/RyftDotNet/src/RyftDotNet/Conversions/Request/GetRateRequest.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/Request/GetRateRequest.cs
@@ -1,0 +1,21 @@
+using RyftDotNet.Utility;
+
+namespace RyftDotNet.Conversions.Request
+{
+    public sealed class GetRateRequest
+    {
+        public string? BuyCurrency { get; set; }
+        public string? SellCurrency { get; set; }
+        public long? Amount { get; set; }
+
+        private const string BuyCurrencyQueryString = "buyCurrency";
+        private const string SellCurrencyQueryString = "sellCurrency";
+        private const string AmountQueryString = "amount";
+
+        internal string ToQueryString() => QueryParameterUtility.BuildQueryString(
+            (BuyCurrencyQueryString, BuyCurrency),
+            (SellCurrencyQueryString, SellCurrency),
+            (AmountQueryString, Amount?.ToString())
+        );
+    }
+}

--- a/RyftDotNet/src/RyftDotNet/Conversions/Request/ListConversionsRequest.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/Request/ListConversionsRequest.cs
@@ -1,0 +1,27 @@
+using RyftDotNet.Utility;
+
+namespace RyftDotNet.Conversions.Request
+{
+    public sealed class ListConversionsRequest
+    {
+        public int? Limit { get; set; }
+        public bool? Ascending { get; set; }
+        public string? StartsAfter { get; set; }
+        public long? StartTimestamp { get; set; }
+        public long? EndTimestamp { get; set; }
+
+        private const string StartTimestampQueryString = "startTimestamp";
+        private const string EndTimestampQueryString = "endTimestamp";
+        private const string LimitQueryString = "limit";
+        private const string AscendingQueryString = "ascending";
+        private const string PaginationTokenQueryString = "startsAfter";
+
+        internal string ToQueryString() => QueryParameterUtility.BuildQueryString(
+            (StartTimestampQueryString, StartTimestamp?.ToString()),
+            (EndTimestampQueryString, EndTimestamp?.ToString()),
+            (LimitQueryString, Limit?.ToString()),
+            (AscendingQueryString, Ascending?.ToString().ToLower()),
+            (PaginationTokenQueryString, StartsAfter)
+        );
+    }
+}

--- a/RyftDotNet/src/RyftDotNet/Conversions/Request/SellConversionRequest.cs
+++ b/RyftDotNet/src/RyftDotNet/Conversions/Request/SellConversionRequest.cs
@@ -1,0 +1,15 @@
+namespace RyftDotNet.Conversions.Request
+{
+    public sealed class SellConversionRequest
+    {
+        public string Currency { get; }
+
+        public long Amount { get; }
+
+        public SellConversionRequest(string currency, long amount)
+        {
+            Currency = currency;
+            Amount = amount;
+        }
+    }
+}

--- a/RyftDotNet/src/RyftDotNet/Utility/JsonConverters/ConstantValueJsonConverterFactory.cs
+++ b/RyftDotNet/src/RyftDotNet/Utility/JsonConverters/ConstantValueJsonConverterFactory.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Serialization;
 using RyftDotNet.Accounts;
 using RyftDotNet.BalanceTransactions;
 using RyftDotNet.Common;
+using RyftDotNet.Conversions;
 using RyftDotNet.Disputes;
 using RyftDotNet.Files;
 using RyftDotNet.InPerson.Orders;
@@ -77,7 +78,8 @@ namespace RyftDotNet.Utility.JsonConverters
             typeof(TerminalTransactionType),
             typeof(TerminalReceiptPrintingStatus),
             typeof(CardProductType),
-            typeof(CardFundingType)
+            typeof(CardFundingType),
+            typeof(ConversionStatus)
         };
 
 
@@ -410,6 +412,12 @@ namespace RyftDotNet.Utility.JsonConverters
             {
                 return new ConstantValueJsonConverter<CardFundingType>(
                     value => new CardFundingType(value)
+                );
+            }
+            if (typeToConvert == typeof(ConversionStatus))
+            {
+                return new ConstantValueJsonConverter<ConversionStatus>(
+                    value => new ConversionStatus(value)
                 );
             }
             throw new NotSupportedException(

--- a/RyftDotNet/test/RyftDotNet.IntegrationTests/ConversionApiClientTest.cs
+++ b/RyftDotNet/test/RyftDotNet.IntegrationTests/ConversionApiClientTest.cs
@@ -12,6 +12,50 @@ public sealed class ConversionApiClientTest
     ));
 
     [Fact]
+    public async Task Client_ShouldBeAbleToCreateConversion()
+    {
+        var request = new CreateConversionRequest(
+            sell: new ConversionSideRequest("GBP") { Amount = 1000 },
+            buy: new ConversionSideRequest("EUR"),
+            termAgreement: true
+        );
+        var created = await apiClient.CreateAsync(request);
+        created.ShouldSatisfyAllConditions(
+            r => r.Id.ShouldNotBeNullOrEmpty(),
+            r => r.Sell.Currency.ShouldBe("GBP"),
+            r => r.Buy.Currency.ShouldBe("EUR")
+        );
+    }
+
+    [Fact]
+    public async Task Client_ShouldBeAbleToGetConversion()
+    {
+        var request = new CreateConversionRequest(
+            sell: new ConversionSideRequest("GBP") { Amount = 1000 },
+            buy: new ConversionSideRequest("EUR"),
+            termAgreement: true
+        );
+        var created = await apiClient.CreateAsync(request);
+
+        var fetched = await apiClient.GetAsync(created.Id);
+        fetched.Id.ShouldBe(created.Id);
+    }
+
+    [Fact]
+    public async Task Client_ShouldBeAbleToListResources()
+    {
+        var request = new CreateConversionRequest(
+            sell: new ConversionSideRequest("GBP") { Amount = 1000 },
+            buy: new ConversionSideRequest("EUR"),
+            termAgreement: true
+        );
+        var created = await apiClient.CreateAsync(request);
+
+        var listed = await apiClient.ListAsync(new ListConversionsRequest { Limit = 1 });
+        listed.Items.ShouldContain(created);
+    }
+
+    [Fact]
     public async Task Client_ShouldBeAbleToGetRate()
     {
         var result = await apiClient.GetRatesAsync(new GetRateRequest
@@ -25,32 +69,5 @@ public sealed class ConversionApiClientTest
             r => r.Buy.ShouldNotBeNull(),
             r => r.Rate.ShouldBeGreaterThan(0)
         );
-    }
-
-    [Fact]
-    public async Task Client_ShouldBeAbleToListResources()
-    {
-        var result = await apiClient.ListAsync(new ListConversionsRequest { Limit = 1 });
-        result.ShouldSatisfyAllConditions(
-            r => r.Items.ShouldNotBeNull()
-        );
-    }
-
-    [Fact]
-    public async Task Client_ShouldBeAbleToCreateAndGetConversion()
-    {
-        var request = new CreateConversionRequest(
-            sell: new ConversionSideRequest("GBP") { Amount = 1000 },
-            buy: new ConversionSideRequest("EUR"),
-            termAgreement: true
-        );
-        var created = await apiClient.CreateAsync(request);
-        created.ShouldSatisfyAllConditions(
-            r => r.Id.ShouldNotBeNullOrEmpty(),
-            r => r.Sell.Currency.ShouldBe("GBP"),
-            r => r.Buy.Currency.ShouldBe("EUR")
-        );
-        var fetched = await apiClient.GetAsync(created.Id);
-        fetched.Id.ShouldBe(created.Id);
     }
 }

--- a/RyftDotNet/test/RyftDotNet.IntegrationTests/ConversionApiClientTest.cs
+++ b/RyftDotNet/test/RyftDotNet.IntegrationTests/ConversionApiClientTest.cs
@@ -15,7 +15,7 @@ public sealed class ConversionApiClientTest
     public async Task Client_ShouldBeAbleToCreateConversion()
     {
         var request = new CreateConversionRequest(
-            sell: new SellConversionRequest("GBP", 1000),
+            sell: new SellConversionRequest("GBP", 500),
             buy: new BuyConversionRequest("EUR"),
             termAgreement: true
         );
@@ -31,7 +31,7 @@ public sealed class ConversionApiClientTest
     public async Task Client_ShouldBeAbleToGetConversion()
     {
         var request = new CreateConversionRequest(
-            sell: new SellConversionRequest("GBP", 1000),
+            sell: new SellConversionRequest("GBP", 500),
             buy: new BuyConversionRequest("EUR"),
             termAgreement: true
         );
@@ -45,7 +45,7 @@ public sealed class ConversionApiClientTest
     public async Task Client_ShouldBeAbleToListResources()
     {
         var request = new CreateConversionRequest(
-            sell: new SellConversionRequest("GBP", 1000),
+            sell: new SellConversionRequest("GBP", 500),
             buy: new BuyConversionRequest("EUR"),
             termAgreement: true
         );

--- a/RyftDotNet/test/RyftDotNet.IntegrationTests/ConversionApiClientTest.cs
+++ b/RyftDotNet/test/RyftDotNet.IntegrationTests/ConversionApiClientTest.cs
@@ -41,14 +41,14 @@ public sealed class ConversionApiClientTest
     {
         var request = new CreateConversionRequest(
             sell: new ConversionSideRequest("GBP") { Amount = 1000 },
-            buy: new ConversionSideRequest("USD"),
+            buy: new ConversionSideRequest("EUR"),
             termAgreement: true
         );
         var created = await apiClient.CreateAsync(request);
         created.ShouldSatisfyAllConditions(
             r => r.Id.ShouldNotBeNullOrEmpty(),
             r => r.Sell.Currency.ShouldBe("GBP"),
-            r => r.Buy.Currency.ShouldBe("USD")
+            r => r.Buy.Currency.ShouldBe("EUR")
         );
         var fetched = await apiClient.GetAsync(created.Id);
         fetched.Id.ShouldBe(created.Id);

--- a/RyftDotNet/test/RyftDotNet.IntegrationTests/ConversionApiClientTest.cs
+++ b/RyftDotNet/test/RyftDotNet.IntegrationTests/ConversionApiClientTest.cs
@@ -14,7 +14,12 @@ public sealed class ConversionApiClientTest
     [Fact]
     public async Task Client_ShouldBeAbleToGetRate()
     {
-        var result = await apiClient.GetRatesAsync();
+        var result = await apiClient.GetRatesAsync(new GetRateRequest
+        {
+            BuyCurrency = "USD",
+            SellCurrency = "GBP",
+            Amount = 1000
+        });
         result.ShouldSatisfyAllConditions(
             r => r.Sell.ShouldNotBeNull(),
             r => r.Buy.ShouldNotBeNull(),

--- a/RyftDotNet/test/RyftDotNet.IntegrationTests/ConversionApiClientTest.cs
+++ b/RyftDotNet/test/RyftDotNet.IntegrationTests/ConversionApiClientTest.cs
@@ -16,7 +16,7 @@ public sealed class ConversionApiClientTest
     {
         var result = await apiClient.GetRatesAsync(new GetRateRequest
         {
-            BuyCurrency = "USD",
+            BuyCurrency = "EUR",
             SellCurrency = "GBP",
             Amount = 1000
         });

--- a/RyftDotNet/test/RyftDotNet.IntegrationTests/ConversionApiClientTest.cs
+++ b/RyftDotNet/test/RyftDotNet.IntegrationTests/ConversionApiClientTest.cs
@@ -14,7 +14,7 @@ public sealed class ConversionApiClientTest
     [Fact]
     public async Task Client_ShouldBeAbleToGetRate()
     {
-        var result = await apiClient.GetRates();
+        var result = await apiClient.GetRatesAsync();
         result.ShouldSatisfyAllConditions(
             r => r.Sell.ShouldNotBeNull(),
             r => r.Buy.ShouldNotBeNull(),
@@ -39,13 +39,13 @@ public sealed class ConversionApiClientTest
             buy: new ConversionSideRequest("USD"),
             termAgreement: true
         );
-        var created = await apiClient.CreateAsync(TestUtility.ExistingConversionAccountId, request);
+        var created = await apiClient.CreateAsync(request);
         created.ShouldSatisfyAllConditions(
             r => r.Id.ShouldNotBeNullOrEmpty(),
             r => r.Sell.Currency.ShouldBe("GBP"),
             r => r.Buy.Currency.ShouldBe("USD")
         );
-        var fetched = await apiClient.GetAsync(TestUtility.ExistingConversionAccountId, created.Id);
+        var fetched = await apiClient.GetAsync(created.Id);
         fetched.Id.ShouldBe(created.Id);
     }
 }

--- a/RyftDotNet/test/RyftDotNet.IntegrationTests/ConversionApiClientTest.cs
+++ b/RyftDotNet/test/RyftDotNet.IntegrationTests/ConversionApiClientTest.cs
@@ -1,0 +1,51 @@
+using RyftDotNet.Client;
+using RyftDotNet.Conversions;
+using RyftDotNet.Conversions.Request;
+using Shouldly;
+
+namespace RyftDotNet.IntegrationTests;
+
+public sealed class ConversionApiClientTest
+{
+    private readonly ConversionApiClient apiClient = new(new RyftApiClient(
+        requestSettings: new ClientRequestSettings { ApiKey = TestUtility.SecretApiKey }
+    ));
+
+    [Fact]
+    public async Task Client_ShouldBeAbleToGetRate()
+    {
+        var result = await apiClient.GetRates();
+        result.ShouldSatisfyAllConditions(
+            r => r.Sell.ShouldNotBeNull(),
+            r => r.Buy.ShouldNotBeNull(),
+            r => r.Rate.ShouldBeGreaterThan(0)
+        );
+    }
+
+    [Fact]
+    public async Task Client_ShouldBeAbleToListResources()
+    {
+        var result = await apiClient.ListAsync(new ListConversionsRequest { Limit = 1 });
+        result.ShouldSatisfyAllConditions(
+            r => r.Items.ShouldNotBeNull()
+        );
+    }
+
+    [Fact]
+    public async Task Client_ShouldBeAbleToCreateAndGetConversion()
+    {
+        var request = new CreateConversionRequest(
+            sell: new ConversionSideRequest("GBP") { Amount = 1000 },
+            buy: new ConversionSideRequest("USD"),
+            termAgreement: true
+        );
+        var created = await apiClient.CreateAsync(TestUtility.ExistingConversionAccountId, request);
+        created.ShouldSatisfyAllConditions(
+            r => r.Id.ShouldNotBeNullOrEmpty(),
+            r => r.Sell.Currency.ShouldBe("GBP"),
+            r => r.Buy.Currency.ShouldBe("USD")
+        );
+        var fetched = await apiClient.GetAsync(TestUtility.ExistingConversionAccountId, created.Id);
+        fetched.Id.ShouldBe(created.Id);
+    }
+}

--- a/RyftDotNet/test/RyftDotNet.IntegrationTests/ConversionApiClientTest.cs
+++ b/RyftDotNet/test/RyftDotNet.IntegrationTests/ConversionApiClientTest.cs
@@ -15,8 +15,8 @@ public sealed class ConversionApiClientTest
     public async Task Client_ShouldBeAbleToCreateConversion()
     {
         var request = new CreateConversionRequest(
-            sell: new ConversionSideRequest("GBP") { Amount = 1000 },
-            buy: new ConversionSideRequest("EUR"),
+            sell: new SellConversionRequest("GBP", 1000),
+            buy: new BuyConversionRequest("EUR"),
             termAgreement: true
         );
         var created = await apiClient.CreateAsync(request);
@@ -31,8 +31,8 @@ public sealed class ConversionApiClientTest
     public async Task Client_ShouldBeAbleToGetConversion()
     {
         var request = new CreateConversionRequest(
-            sell: new ConversionSideRequest("GBP") { Amount = 1000 },
-            buy: new ConversionSideRequest("EUR"),
+            sell: new SellConversionRequest("GBP", 1000),
+            buy: new BuyConversionRequest("EUR"),
             termAgreement: true
         );
         var created = await apiClient.CreateAsync(request);
@@ -45,8 +45,8 @@ public sealed class ConversionApiClientTest
     public async Task Client_ShouldBeAbleToListResources()
     {
         var request = new CreateConversionRequest(
-            sell: new ConversionSideRequest("GBP") { Amount = 1000 },
-            buy: new ConversionSideRequest("EUR"),
+            sell: new SellConversionRequest("GBP", 1000),
+            buy: new BuyConversionRequest("EUR"),
             termAgreement: true
         );
         var created = await apiClient.CreateAsync(request);
@@ -58,7 +58,7 @@ public sealed class ConversionApiClientTest
     [Fact]
     public async Task Client_ShouldBeAbleToGetRate()
     {
-        var result = await apiClient.GetRatesAsync(new GetRateRequest
+        var result = await apiClient.GetRateAsync(new GetRateRequest
         {
             BuyCurrency = "EUR",
             SellCurrency = "GBP",

--- a/RyftDotNet/test/RyftDotNet.IntegrationTests/TestUtility.cs
+++ b/RyftDotNet/test/RyftDotNet.IntegrationTests/TestUtility.cs
@@ -11,7 +11,6 @@ internal static class TestUtility
     private const string HostedAccountIdEnvVar = "RYFT_HOSTED_ACCOUNT_ID";
     private const string NonHostedAccountIdEnvVar = "RYFT_NON_HOSTED_ACCOUNT_ID";
     private const string PlatformFeeIdEnvVar = "RYFT_PLATFORM_FEE_ID";
-    private const string ConversionAccountIdEnvVar = "RYFT_CONVERSION_ACCOUNT_ID";
 
     internal static readonly string SecretApiKey =
         Environment.GetEnvironmentVariable(ApiKeyEnvVar)
@@ -40,10 +39,6 @@ internal static class TestUtility
     internal static readonly string ExistingPlatformFeeId
         = Environment.GetEnvironmentVariable(PlatformFeeIdEnvVar)
           ?? throw new TestClassException($"Missing {PlatformFeeIdEnvVar} environment variable");
-
-    internal static readonly string ExistingConversionAccountId
-        = Environment.GetEnvironmentVariable(ConversionAccountIdEnvVar)
-          ?? throw new TestClassException($"Missing {ConversionAccountIdEnvVar} environment variable");
 
     internal static string ResourcePrefix() =>
         $"ryft-dotnet_{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";

--- a/RyftDotNet/test/RyftDotNet.IntegrationTests/TestUtility.cs
+++ b/RyftDotNet/test/RyftDotNet.IntegrationTests/TestUtility.cs
@@ -11,6 +11,7 @@ internal static class TestUtility
     private const string HostedAccountIdEnvVar = "RYFT_HOSTED_ACCOUNT_ID";
     private const string NonHostedAccountIdEnvVar = "RYFT_NON_HOSTED_ACCOUNT_ID";
     private const string PlatformFeeIdEnvVar = "RYFT_PLATFORM_FEE_ID";
+    private const string ConversionAccountIdEnvVar = "RYFT_CONVERSION_ACCOUNT_ID";
 
     internal static readonly string SecretApiKey =
         Environment.GetEnvironmentVariable(ApiKeyEnvVar)
@@ -39,6 +40,10 @@ internal static class TestUtility
     internal static readonly string ExistingPlatformFeeId
         = Environment.GetEnvironmentVariable(PlatformFeeIdEnvVar)
           ?? throw new TestClassException($"Missing {PlatformFeeIdEnvVar} environment variable");
+
+    internal static readonly string ExistingConversionAccountId
+        = Environment.GetEnvironmentVariable(ConversionAccountIdEnvVar)
+          ?? throw new TestClassException($"Missing {ConversionAccountIdEnvVar} environment variable");
 
     internal static string ResourcePrefix() =>
         $"ryft-dotnet_{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";

--- a/RyftDotNet/test/RyftDotNet.Tests/Conversions/ConversionApiClientTest.cs
+++ b/RyftDotNet/test/RyftDotNet.Tests/Conversions/ConversionApiClientTest.cs
@@ -42,7 +42,7 @@ namespace RyftDotNet.Tests.Conversions
                 .RequestAsync<Conversion>()
                 .RecordInvokedArguments(args => arguments = args)
                 .ReturnsAsync(conversion);
-            await apiClient.CreateAsync(TestData.AccountId, request);
+            await apiClient.CreateAsync(request);
             arguments.ShouldBe(new ExpectedRequestArguments(
                 "conversions",
                 HttpMethod.Post,
@@ -61,7 +61,7 @@ namespace RyftDotNet.Tests.Conversions
             );
             var exception = new RyftApiException("uh oh");
             ryftApiClient.RequestAsync<Conversion>().ThrowsAsync(exception);
-            Func<Task<Conversion>> action = async () => await apiClient.CreateAsync(TestData.AccountId, request);
+            Func<Task<Conversion>> action = async () => await apiClient.CreateAsync(request);
             var thrown = await action.ShouldThrowAsync<RyftApiException>();
             thrown.ShouldBeSameAs(exception);
         }
@@ -75,7 +75,7 @@ namespace RyftDotNet.Tests.Conversions
                 termAgreement: true
             );
             ryftApiClient.RequestAsync<Conversion>().ReturnsAsync(conversion);
-            var result = await apiClient.CreateAsync(TestData.AccountId, request);
+            var result = await apiClient.CreateAsync(request);
             result.ShouldBe(conversion);
         }
 
@@ -87,7 +87,7 @@ namespace RyftDotNet.Tests.Conversions
                 .RequestAsync<Conversion>()
                 .RecordInvokedArguments(args => arguments = args)
                 .ReturnsAsync(conversion);
-            await apiClient.GetAsync(TestData.AccountId, conversion.Id);
+            await apiClient.GetAsync(conversion.Id);
             arguments.ShouldBe(new ExpectedRequestArguments(
                 $"conversions/{conversion.Id}",
                 HttpMethod.Get,
@@ -101,7 +101,7 @@ namespace RyftDotNet.Tests.Conversions
         {
             var exception = new RyftApiException("uh oh");
             ryftApiClient.RequestAsync<Conversion>().ThrowsAsync(exception);
-            Func<Task<Conversion>> action = async () => await apiClient.GetAsync(TestData.AccountId, conversion.Id);
+            Func<Task<Conversion>> action = async () => await apiClient.GetAsync(conversion.Id);
             var thrown = await action.ShouldThrowAsync<RyftApiException>();
             thrown.ShouldBeSameAs(exception);
         }
@@ -110,7 +110,7 @@ namespace RyftDotNet.Tests.Conversions
         public async Task GetAsync_ShouldReturnResource_WhenSuccessful()
         {
             ryftApiClient.RequestAsync<Conversion>().ReturnsAsync(conversion);
-            var result = await apiClient.GetAsync(TestData.AccountId, conversion.Id);
+            var result = await apiClient.GetAsync(conversion.Id);
             result.ShouldBe(conversion);
         }
 
@@ -167,14 +167,14 @@ namespace RyftDotNet.Tests.Conversions
         }
 
         [Fact]
-        public async Task GetRates_ShouldIssueRequestWithExpectedArguments()
+        public async Task GetRatesAsync_ShouldIssueRequestWithExpectedArguments()
         {
             ExpectedRequestArguments? arguments = null;
             ryftApiClient
                 .RequestAsync<ConversionRate>()
                 .RecordInvokedArguments(args => arguments = args)
                 .ReturnsAsync(conversionRate);
-            await apiClient.GetRates();
+            await apiClient.GetRatesAsync();
             arguments.ShouldBe(new ExpectedRequestArguments(
                 "conversions/rate",
                 HttpMethod.Get,
@@ -184,7 +184,7 @@ namespace RyftDotNet.Tests.Conversions
         }
 
         [Fact]
-        public async Task GetRates_ShouldIssueRequestWithExpectedArguments_WhenQueryParamsProvided()
+        public async Task GetRatesAsync_ShouldIssueRequestWithExpectedArguments_WhenQueryParamsProvided()
         {
             var request = new GetRateRequest { BuyCurrency = "USD", SellCurrency = "GBP", Amount = 1000 };
             ExpectedRequestArguments? arguments = null;
@@ -192,7 +192,7 @@ namespace RyftDotNet.Tests.Conversions
                 .RequestAsync<ConversionRate>()
                 .RecordInvokedArguments(args => arguments = args)
                 .ReturnsAsync(conversionRate);
-            await apiClient.GetRates(request);
+            await apiClient.GetRatesAsync(request);
             arguments.ShouldBe(new ExpectedRequestArguments(
                 $"conversions/rate{request.ToQueryString()}",
                 HttpMethod.Get,
@@ -202,20 +202,20 @@ namespace RyftDotNet.Tests.Conversions
         }
 
         [Fact]
-        public async Task GetRates_ShouldPropagateException_WhenUnderlyingClientThrows()
+        public async Task GetRatesAsync_ShouldPropagateException_WhenUnderlyingClientThrows()
         {
             var exception = new RyftApiException("uh oh");
             ryftApiClient.RequestAsync<ConversionRate>().ThrowsAsync(exception);
-            Func<Task<ConversionRate>> action = async () => await apiClient.GetRates();
+            Func<Task<ConversionRate>> action = async () => await apiClient.GetRatesAsync();
             var thrown = await action.ShouldThrowAsync<RyftApiException>();
             thrown.ShouldBeSameAs(exception);
         }
 
         [Fact]
-        public async Task GetRates_ShouldReturnResource_WhenSuccessful()
+        public async Task GetRatesAsync_ShouldReturnResource_WhenSuccessful()
         {
             ryftApiClient.RequestAsync<ConversionRate>().ReturnsAsync(conversionRate);
-            var result = await apiClient.GetRates();
+            var result = await apiClient.GetRatesAsync();
             result.ShouldBe(conversionRate);
         }
     }

--- a/RyftDotNet/test/RyftDotNet.Tests/Conversions/ConversionApiClientTest.cs
+++ b/RyftDotNet/test/RyftDotNet.Tests/Conversions/ConversionApiClientTest.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Moq;
+using RyftDotNet.Client;
+using RyftDotNet.Client.Error;
+using RyftDotNet.Common;
+using RyftDotNet.Conversions;
+using RyftDotNet.Conversions.Request;
+using RyftDotNet.Utility;
+using Shouldly;
+using Xunit;
+
+namespace RyftDotNet.Tests.Conversions
+{
+    public sealed class ConversionApiClientTest
+    {
+        private readonly Mock<IRyftApiClient> ryftApiClient;
+        private readonly ConversionApiClient apiClient;
+
+        private readonly Conversion conversion = TestData.Conversion();
+        private readonly ConversionRate conversionRate = TestData.ConversionRate();
+
+        public ConversionApiClientTest()
+        {
+            ryftApiClient = new Mock<IRyftApiClient>();
+            apiClient = new ConversionApiClient(ryftApiClient.Object);
+        }
+
+        [Fact]
+        public async Task CreateAsync_ShouldIssueRequestWithExpectedArguments()
+        {
+            var request = new CreateConversionRequest(
+                new ConversionSideRequest("GBP") { Amount = 1000 },
+                new ConversionSideRequest("USD"),
+                termAgreement: true
+            );
+            ExpectedRequestArguments? arguments = null;
+            ryftApiClient
+                .RequestAsync<Conversion>()
+                .RecordInvokedArguments(args => arguments = args)
+                .ReturnsAsync(conversion);
+            await apiClient.CreateAsync(TestData.AccountId, request);
+            arguments.ShouldBe(new ExpectedRequestArguments(
+                "conversions",
+                HttpMethod.Post,
+                HttpStatusCode.OK,
+                request
+            ));
+        }
+
+        [Fact]
+        public async Task CreateAsync_ShouldPropagateException_WhenUnderlyingClientThrows()
+        {
+            var request = new CreateConversionRequest(
+                new ConversionSideRequest("GBP") { Amount = 1000 },
+                new ConversionSideRequest("USD"),
+                termAgreement: true
+            );
+            var exception = new RyftApiException("uh oh");
+            ryftApiClient.RequestAsync<Conversion>().ThrowsAsync(exception);
+            Func<Task<Conversion>> action = async () => await apiClient.CreateAsync(TestData.AccountId, request);
+            var thrown = await action.ShouldThrowAsync<RyftApiException>();
+            thrown.ShouldBeSameAs(exception);
+        }
+
+        [Fact]
+        public async Task CreateAsync_ShouldReturnResource_WhenSuccessful()
+        {
+            var request = new CreateConversionRequest(
+                new ConversionSideRequest("GBP") { Amount = 1000 },
+                new ConversionSideRequest("USD"),
+                termAgreement: true
+            );
+            ryftApiClient.RequestAsync<Conversion>().ReturnsAsync(conversion);
+            var result = await apiClient.CreateAsync(TestData.AccountId, request);
+            result.ShouldBe(conversion);
+        }
+
+        [Fact]
+        public async Task GetAsync_ShouldIssueRequestWithExpectedArguments()
+        {
+            ExpectedRequestArguments? arguments = null;
+            ryftApiClient
+                .RequestAsync<Conversion>()
+                .RecordInvokedArguments(args => arguments = args)
+                .ReturnsAsync(conversion);
+            await apiClient.GetAsync(TestData.AccountId, conversion.Id);
+            arguments.ShouldBe(new ExpectedRequestArguments(
+                $"conversions/{conversion.Id}",
+                HttpMethod.Get,
+                HttpStatusCode.OK,
+                null
+            ));
+        }
+
+        [Fact]
+        public async Task GetAsync_ShouldPropagateException_WhenUnderlyingClientThrows()
+        {
+            var exception = new RyftApiException("uh oh");
+            ryftApiClient.RequestAsync<Conversion>().ThrowsAsync(exception);
+            Func<Task<Conversion>> action = async () => await apiClient.GetAsync(TestData.AccountId, conversion.Id);
+            var thrown = await action.ShouldThrowAsync<RyftApiException>();
+            thrown.ShouldBeSameAs(exception);
+        }
+
+        [Fact]
+        public async Task GetAsync_ShouldReturnResource_WhenSuccessful()
+        {
+            ryftApiClient.RequestAsync<Conversion>().ReturnsAsync(conversion);
+            var result = await apiClient.GetAsync(TestData.AccountId, conversion.Id);
+            result.ShouldBe(conversion);
+        }
+
+        [Fact]
+        public async Task ListAsync_ShouldIssueRequestWithExpectedArguments()
+        {
+            ExpectedRequestArguments? arguments = null;
+            ryftApiClient.RequestAsync<PaginatedResponse<Conversion>>()
+                .RecordInvokedArguments(args => arguments = args)
+                .ReturnsAsync(new PaginatedResponse<Conversion>(new List<Conversion> { conversion }));
+            await apiClient.ListAsync();
+            arguments.ShouldBe(new ExpectedRequestArguments(
+                "conversions",
+                HttpMethod.Get,
+                HttpStatusCode.OK,
+                null
+            ));
+        }
+
+        [Fact]
+        public async Task ListAsync_ShouldIssueRequestWithExpectedArguments_WhenQueryParamsProvided()
+        {
+            var request = new ListConversionsRequest { Ascending = false, Limit = 10 };
+            ExpectedRequestArguments? arguments = null;
+            ryftApiClient.RequestAsync<PaginatedResponse<Conversion>>()
+                .RecordInvokedArguments(args => arguments = args)
+                .ReturnsAsync(new PaginatedResponse<Conversion>(new List<Conversion> { conversion }));
+            await apiClient.ListAsync(request);
+            arguments.ShouldBe(new ExpectedRequestArguments(
+                $"conversions{request.ToQueryString()}",
+                HttpMethod.Get,
+                HttpStatusCode.OK,
+                null
+            ));
+        }
+
+        [Fact]
+        public async Task ListAsync_ShouldPropagateException_WhenUnderlyingClientThrows()
+        {
+            var exception = new RyftApiException("uh oh");
+            ryftApiClient.RequestAsync<PaginatedResponse<Conversion>>().ThrowsAsync(exception);
+            Func<Task<PaginatedResponse<Conversion>>> action = async () => await apiClient.ListAsync();
+            var thrown = await action.ShouldThrowAsync<RyftApiException>();
+            thrown.ShouldBeSameAs(exception);
+        }
+
+        [Fact]
+        public async Task ListAsync_ShouldReturnResource_WhenSuccessful()
+        {
+            var response = new PaginatedResponse<Conversion>(new List<Conversion> { conversion });
+            ryftApiClient.RequestAsync<PaginatedResponse<Conversion>>().ReturnsAsync(response);
+            var result = await apiClient.ListAsync();
+            result.ShouldBe(response);
+        }
+
+        [Fact]
+        public async Task GetRates_ShouldIssueRequestWithExpectedArguments()
+        {
+            ExpectedRequestArguments? arguments = null;
+            ryftApiClient
+                .RequestAsync<ConversionRate>()
+                .RecordInvokedArguments(args => arguments = args)
+                .ReturnsAsync(conversionRate);
+            await apiClient.GetRates();
+            arguments.ShouldBe(new ExpectedRequestArguments(
+                "conversions/rate",
+                HttpMethod.Get,
+                HttpStatusCode.OK,
+                null
+            ));
+        }
+
+        [Fact]
+        public async Task GetRates_ShouldIssueRequestWithExpectedArguments_WhenQueryParamsProvided()
+        {
+            var request = new GetRateRequest { BuyCurrency = "USD", SellCurrency = "GBP", Amount = 1000 };
+            ExpectedRequestArguments? arguments = null;
+            ryftApiClient
+                .RequestAsync<ConversionRate>()
+                .RecordInvokedArguments(args => arguments = args)
+                .ReturnsAsync(conversionRate);
+            await apiClient.GetRates(request);
+            arguments.ShouldBe(new ExpectedRequestArguments(
+                $"conversions/rate{request.ToQueryString()}",
+                HttpMethod.Get,
+                HttpStatusCode.OK,
+                null
+            ));
+        }
+
+        [Fact]
+        public async Task GetRates_ShouldPropagateException_WhenUnderlyingClientThrows()
+        {
+            var exception = new RyftApiException("uh oh");
+            ryftApiClient.RequestAsync<ConversionRate>().ThrowsAsync(exception);
+            Func<Task<ConversionRate>> action = async () => await apiClient.GetRates();
+            var thrown = await action.ShouldThrowAsync<RyftApiException>();
+            thrown.ShouldBeSameAs(exception);
+        }
+
+        [Fact]
+        public async Task GetRates_ShouldReturnResource_WhenSuccessful()
+        {
+            ryftApiClient.RequestAsync<ConversionRate>().ReturnsAsync(conversionRate);
+            var result = await apiClient.GetRates();
+            result.ShouldBe(conversionRate);
+        }
+    }
+}

--- a/RyftDotNet/test/RyftDotNet.Tests/Conversions/ConversionApiClientTest.cs
+++ b/RyftDotNet/test/RyftDotNet.Tests/Conversions/ConversionApiClientTest.cs
@@ -33,8 +33,8 @@ namespace RyftDotNet.Tests.Conversions
         public async Task CreateAsync_ShouldIssueRequestWithExpectedArguments()
         {
             var request = new CreateConversionRequest(
-                new ConversionSideRequest("GBP") { Amount = 1000 },
-                new ConversionSideRequest("USD"),
+                new SellConversionRequest("GBP", 1000),
+                new BuyConversionRequest("USD"),
                 termAgreement: true
             );
             ExpectedRequestArguments? arguments = null;
@@ -55,8 +55,8 @@ namespace RyftDotNet.Tests.Conversions
         public async Task CreateAsync_ShouldPropagateException_WhenUnderlyingClientThrows()
         {
             var request = new CreateConversionRequest(
-                new ConversionSideRequest("GBP") { Amount = 1000 },
-                new ConversionSideRequest("USD"),
+                new SellConversionRequest("GBP", 1000),
+                new BuyConversionRequest("USD"),
                 termAgreement: true
             );
             var exception = new RyftApiException("uh oh");
@@ -70,8 +70,8 @@ namespace RyftDotNet.Tests.Conversions
         public async Task CreateAsync_ShouldReturnResource_WhenSuccessful()
         {
             var request = new CreateConversionRequest(
-                new ConversionSideRequest("GBP") { Amount = 1000 },
-                new ConversionSideRequest("USD"),
+                new SellConversionRequest("GBP", 1000),
+                new BuyConversionRequest("USD"),
                 termAgreement: true
             );
             ryftApiClient.RequestAsync<Conversion>().ReturnsAsync(conversion);
@@ -167,14 +167,14 @@ namespace RyftDotNet.Tests.Conversions
         }
 
         [Fact]
-        public async Task GetRatesAsync_ShouldIssueRequestWithExpectedArguments()
+        public async Task GetRateAsync_ShouldIssueRequestWithExpectedArguments()
         {
             ExpectedRequestArguments? arguments = null;
             ryftApiClient
                 .RequestAsync<ConversionRate>()
                 .RecordInvokedArguments(args => arguments = args)
                 .ReturnsAsync(conversionRate);
-            await apiClient.GetRatesAsync();
+            await apiClient.GetRateAsync();
             arguments.ShouldBe(new ExpectedRequestArguments(
                 "conversions/rate",
                 HttpMethod.Get,
@@ -184,7 +184,7 @@ namespace RyftDotNet.Tests.Conversions
         }
 
         [Fact]
-        public async Task GetRatesAsync_ShouldIssueRequestWithExpectedArguments_WhenQueryParamsProvided()
+        public async Task GetRateAsync_ShouldIssueRequestWithExpectedArguments_WhenQueryParamsProvided()
         {
             var request = new GetRateRequest { BuyCurrency = "USD", SellCurrency = "GBP", Amount = 1000 };
             ExpectedRequestArguments? arguments = null;
@@ -192,7 +192,7 @@ namespace RyftDotNet.Tests.Conversions
                 .RequestAsync<ConversionRate>()
                 .RecordInvokedArguments(args => arguments = args)
                 .ReturnsAsync(conversionRate);
-            await apiClient.GetRatesAsync(request);
+            await apiClient.GetRateAsync(request);
             arguments.ShouldBe(new ExpectedRequestArguments(
                 $"conversions/rate{request.ToQueryString()}",
                 HttpMethod.Get,
@@ -202,20 +202,20 @@ namespace RyftDotNet.Tests.Conversions
         }
 
         [Fact]
-        public async Task GetRatesAsync_ShouldPropagateException_WhenUnderlyingClientThrows()
+        public async Task GetRateAsync_ShouldPropagateException_WhenUnderlyingClientThrows()
         {
             var exception = new RyftApiException("uh oh");
             ryftApiClient.RequestAsync<ConversionRate>().ThrowsAsync(exception);
-            Func<Task<ConversionRate>> action = async () => await apiClient.GetRatesAsync();
+            Func<Task<ConversionRate>> action = async () => await apiClient.GetRateAsync();
             var thrown = await action.ShouldThrowAsync<RyftApiException>();
             thrown.ShouldBeSameAs(exception);
         }
 
         [Fact]
-        public async Task GetRatesAsync_ShouldReturnResource_WhenSuccessful()
+        public async Task GetRateAsync_ShouldReturnResource_WhenSuccessful()
         {
             ryftApiClient.RequestAsync<ConversionRate>().ReturnsAsync(conversionRate);
-            var result = await apiClient.GetRatesAsync();
+            var result = await apiClient.GetRateAsync();
             result.ShouldBe(conversionRate);
         }
     }

--- a/RyftDotNet/test/RyftDotNet.Tests/Conversions/ConversionRateTest.cs
+++ b/RyftDotNet/test/RyftDotNet.Tests/Conversions/ConversionRateTest.cs
@@ -1,0 +1,26 @@
+using System.IO;
+using RyftDotNet.Conversions;
+using RyftDotNet.Utility;
+using Shouldly;
+using Xunit;
+
+namespace RyftDotNet.Tests.Conversions
+{
+    public sealed class ConversionRateTest
+    {
+        [Fact]
+        public void FromJson_ShouldReturnExpectedValue()
+        {
+            string json = File.ReadAllText("assets/conversions/rate.json");
+            JsonUtility.Deserialize<ConversionRate>(json).ShouldBe(new ConversionRate(
+                new ConversionRateSell(1000L, "GBP"),
+                new ConversionRateBuy(1247L, "USD", new ConversionFees(
+                    new ConversionFee(10L),
+                    new ConversionPlatformFeeDetail(5L, new ConversionFee(2L))
+                )),
+                1.247m,
+                "2024-03-15"
+            ));
+        }
+    }
+}

--- a/RyftDotNet/test/RyftDotNet.Tests/Conversions/ConversionRateTest.cs
+++ b/RyftDotNet/test/RyftDotNet.Tests/Conversions/ConversionRateTest.cs
@@ -13,7 +13,7 @@ namespace RyftDotNet.Tests.Conversions
         {
             string json = File.ReadAllText("assets/conversions/rate.json");
             JsonUtility.Deserialize<ConversionRate>(json).ShouldBe(new ConversionRate(
-                new ConversionRateSell(1000L, "GBP"),
+                new ConversionRateSell(1000L, "GBP", new ConversionFees(new ConversionFee(8L), null)),
                 new ConversionRateBuy(1247L, "USD", new ConversionFees(
                     new ConversionFee(10L),
                     new ConversionPlatformFeeDetail(5L, new ConversionFee(2L))

--- a/RyftDotNet/test/RyftDotNet.Tests/Conversions/ConversionStatusTest.cs
+++ b/RyftDotNet/test/RyftDotNet.Tests/Conversions/ConversionStatusTest.cs
@@ -1,0 +1,20 @@
+using RyftDotNet.Conversions;
+using Shouldly;
+using Xunit;
+
+namespace RyftDotNet.Tests.Conversions
+{
+    public sealed class ConversionStatusTest
+    {
+        [Theory, MemberData(nameof(ExpectedValues))]
+        public void StaticValues_ShouldReturnExpectedValue(ConversionStatus actual, ConversionStatus expected)
+            => actual.ShouldBe(expected);
+
+        public static TheoryData<ConversionStatus, ConversionStatus> ExpectedValues() =>
+            new TheoryData<ConversionStatus, ConversionStatus>
+            {
+                { ConversionStatus.InProgress, new ConversionStatus("InProgress") },
+                { ConversionStatus.Settled, new ConversionStatus("Settled") }
+            };
+    }
+}

--- a/RyftDotNet/test/RyftDotNet.Tests/Conversions/ConversionTest.cs
+++ b/RyftDotNet/test/RyftDotNet.Tests/Conversions/ConversionTest.cs
@@ -1,0 +1,50 @@
+using System.IO;
+using RyftDotNet.Conversions;
+using RyftDotNet.Utility;
+using Shouldly;
+using Xunit;
+
+namespace RyftDotNet.Tests.Conversions
+{
+    public sealed class ConversionTest
+    {
+        [Fact]
+        public void FromJson_ShouldReturnExpectedValue_WhenMinimumRequiredFieldsReturned()
+        {
+            string json = File.ReadAllText("assets/conversions/conversion-min.json");
+            JsonUtility.Deserialize<Conversion>(json).ShouldBe(new Conversion(
+                "con_01FCTS1XMKH9FF43CAFA4CXT3P",
+                new ConversionSell(null, "GBP"),
+                new ConversionBuy(null, "USD", null),
+                null,
+                ConversionStatus.InProgress,
+                null,
+                null,
+                null,
+                null,
+                1470989538L
+            ));
+        }
+
+        [Fact]
+        public void FromJson_ShouldReturnExpectedValue_WhenAllFieldsReturned()
+        {
+            string json = File.ReadAllText("assets/conversions/conversion-full.json");
+            JsonUtility.Deserialize<Conversion>(json).ShouldBe(new Conversion(
+                "con_01FCTS1XMKH9FF43CAFA4CXT3P",
+                new ConversionSell(1000L, "GBP"),
+                new ConversionBuy(1247L, "USD", new ConversionFees(
+                    new ConversionFee(10L),
+                    new ConversionPlatformFeeDetail(5L, new ConversionFee(2L))
+                )),
+                1.247m,
+                ConversionStatus.Settled,
+                "FX conversion",
+                "2024-03-15",
+                1470989600L,
+                new ConversionCreatedBy("ac_b83f2653-06d7-44a9-a548-5825e8186004", "Test Account"),
+                1470989538L
+            ));
+        }
+    }
+}

--- a/RyftDotNet/test/RyftDotNet.Tests/Conversions/ConversionTest.cs
+++ b/RyftDotNet/test/RyftDotNet.Tests/Conversions/ConversionTest.cs
@@ -14,7 +14,7 @@ namespace RyftDotNet.Tests.Conversions
             string json = File.ReadAllText("assets/conversions/conversion-min.json");
             JsonUtility.Deserialize<Conversion>(json).ShouldBe(new Conversion(
                 "con_01FCTS1XMKH9FF43CAFA4CXT3P",
-                new ConversionSell(null, "GBP", null),
+                new ConversionSell(1000L, "GBP", null),
                 new ConversionBuy(null, "USD", null),
                 null,
                 ConversionStatus.InProgress,

--- a/RyftDotNet/test/RyftDotNet.Tests/Conversions/ConversionTest.cs
+++ b/RyftDotNet/test/RyftDotNet.Tests/Conversions/ConversionTest.cs
@@ -14,7 +14,7 @@ namespace RyftDotNet.Tests.Conversions
             string json = File.ReadAllText("assets/conversions/conversion-min.json");
             JsonUtility.Deserialize<Conversion>(json).ShouldBe(new Conversion(
                 "con_01FCTS1XMKH9FF43CAFA4CXT3P",
-                new ConversionSell(null, "GBP"),
+                new ConversionSell(1000L, "GBP"),
                 new ConversionBuy(null, "USD", null),
                 null,
                 ConversionStatus.InProgress,

--- a/RyftDotNet/test/RyftDotNet.Tests/Conversions/ConversionTest.cs
+++ b/RyftDotNet/test/RyftDotNet.Tests/Conversions/ConversionTest.cs
@@ -14,7 +14,7 @@ namespace RyftDotNet.Tests.Conversions
             string json = File.ReadAllText("assets/conversions/conversion-min.json");
             JsonUtility.Deserialize<Conversion>(json).ShouldBe(new Conversion(
                 "con_01FCTS1XMKH9FF43CAFA4CXT3P",
-                new ConversionSell(1000L, "GBP"),
+                new ConversionSell(null, "GBP", null),
                 new ConversionBuy(null, "USD", null),
                 null,
                 ConversionStatus.InProgress,
@@ -32,7 +32,7 @@ namespace RyftDotNet.Tests.Conversions
             string json = File.ReadAllText("assets/conversions/conversion-full.json");
             JsonUtility.Deserialize<Conversion>(json).ShouldBe(new Conversion(
                 "con_01FCTS1XMKH9FF43CAFA4CXT3P",
-                new ConversionSell(1000L, "GBP"),
+                new ConversionSell(1000L, "GBP", null),
                 new ConversionBuy(1247L, "USD", new ConversionFees(
                     new ConversionFee(10L),
                     new ConversionPlatformFeeDetail(5L, new ConversionFee(2L))

--- a/RyftDotNet/test/RyftDotNet.Tests/Conversions/Request/GetRateRequestTest.cs
+++ b/RyftDotNet/test/RyftDotNet.Tests/Conversions/Request/GetRateRequestTest.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using RyftDotNet.Conversions.Request;
+using Shouldly;
+using Xunit;
+
+namespace RyftDotNet.Tests.Conversions.Request
+{
+    public sealed class GetRateRequestTest
+    {
+        [Theory, MemberData(nameof(ExpectedQueryStrings))]
+        public void ToQueryString_ShouldReturnExpectedValue(GetRateRequest request, string expected)
+            => request.ToQueryString().ShouldBe(expected);
+
+        public static IEnumerable<object[]> ExpectedQueryStrings()
+        {
+            yield return
+                new object[] { new GetRateRequest(), string.Empty };
+            yield return
+                new object[] { new GetRateRequest { SellCurrency = "GBP" }, "?sellCurrency=GBP" };
+            yield return
+                new object[] { new GetRateRequest { BuyCurrency = "USD" }, "?buyCurrency=USD" };
+            yield return
+                new object[] { new GetRateRequest { Amount = 1000L }, "?amount=1000" };
+            yield return
+                new object[]
+                {
+                    new GetRateRequest { SellCurrency = "GBP", BuyCurrency = "USD", Amount = 1000L },
+                    "?buyCurrency=USD&sellCurrency=GBP&amount=1000"
+                };
+        }
+    }
+}

--- a/RyftDotNet/test/RyftDotNet.Tests/Conversions/Request/ListConversionsRequestTest.cs
+++ b/RyftDotNet/test/RyftDotNet.Tests/Conversions/Request/ListConversionsRequestTest.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using RyftDotNet.Conversions.Request;
+using Shouldly;
+using Xunit;
+
+namespace RyftDotNet.Tests.Conversions.Request
+{
+    public sealed class ListConversionsRequestTest
+    {
+        [Theory, MemberData(nameof(ExpectedQueryStrings))]
+        public void ToQueryString_ShouldReturnExpectedValue(ListConversionsRequest request, string expected)
+            => request.ToQueryString().ShouldBe(expected);
+
+        public static IEnumerable<object[]> ExpectedQueryStrings()
+        {
+            yield return
+                new object[] { new ListConversionsRequest(), string.Empty };
+            yield return
+                new object[] { new ListConversionsRequest { Limit = 5 }, "?limit=5" };
+            yield return
+                new object[] { new ListConversionsRequest { Ascending = true }, "?ascending=true" };
+            yield return
+                new object[] { new ListConversionsRequest { Ascending = false, Limit = 2 }, "?limit=2&ascending=false" };
+            yield return
+                new object[]
+                {
+                    new ListConversionsRequest { StartsAfter = "con_01FCTS1XMKH9FF43CAFA4CXT3P" },
+                    "?startsAfter=con_01FCTS1XMKH9FF43CAFA4CXT3P"
+                };
+            yield return
+                new object[]
+                {
+                    new ListConversionsRequest
+                    {
+                        Limit = 2,
+                        Ascending = false,
+                        StartTimestamp = 1631696701L,
+                        EndTimestamp = 1631696705L
+                    },
+                    "?startTimestamp=1631696701&endTimestamp=1631696705&limit=2&ascending=false"
+                };
+        }
+    }
+}

--- a/RyftDotNet/test/RyftDotNet.Tests/RyftDotNet.Tests.csproj
+++ b/RyftDotNet/test/RyftDotNet.Tests/RyftDotNet.Tests.csproj
@@ -85,6 +85,9 @@
     <None Update="assets\errors\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="assets\conversions\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/RyftDotNet/test/RyftDotNet.Tests/TestData.cs
+++ b/RyftDotNet/test/RyftDotNet.Tests/TestData.cs
@@ -7,6 +7,7 @@ using RyftDotNet.ApplePay.Sessions;
 using RyftDotNet.ApplePay.WebDomains;
 using RyftDotNet.Common;
 using RyftDotNet.Common.Request;
+using RyftDotNet.Conversions;
 using RyftDotNet.Customers;
 using RyftDotNet.Disputes;
 using RyftDotNet.Events;
@@ -63,6 +64,26 @@ namespace RyftDotNet.Tests
             "GB",
             "SP4 7DE",
             "Salisbury Plain"
+        );
+
+        internal static Conversion Conversion() => new Conversion(
+            "con_01FCTS1XMKH9FF43CAFA4CXT3P",
+            new ConversionSell(1000L, "GBP"),
+            new ConversionBuy(1247L, "USD", null),
+            1.247m,
+            ConversionStatus.InProgress,
+            null,
+            null,
+            null,
+            null,
+            1470989538L
+        );
+
+        internal static ConversionRate ConversionRate() => new ConversionRate(
+            new ConversionRateSell(1000L, "GBP"),
+            new ConversionRateBuy(1247L, "USD", new ConversionFees(new ConversionFee(10L), null)),
+            1.247m,
+            null
         );
 
         internal static Customer Customer() => new Customer(

--- a/RyftDotNet/test/RyftDotNet.Tests/TestData.cs
+++ b/RyftDotNet/test/RyftDotNet.Tests/TestData.cs
@@ -68,7 +68,7 @@ namespace RyftDotNet.Tests
 
         internal static Conversion Conversion() => new Conversion(
             "con_01FCTS1XMKH9FF43CAFA4CXT3P",
-            new ConversionSell(1000L, "GBP"),
+            new ConversionSell(1000L, "GBP", null),
             new ConversionBuy(1247L, "USD", null),
             1.247m,
             ConversionStatus.InProgress,
@@ -80,7 +80,7 @@ namespace RyftDotNet.Tests
         );
 
         internal static ConversionRate ConversionRate() => new ConversionRate(
-            new ConversionRateSell(1000L, "GBP"),
+            new ConversionRateSell(1000L, "GBP", null),
             new ConversionRateBuy(1247L, "USD", new ConversionFees(new ConversionFee(10L), null)),
             1.247m,
             null

--- a/RyftDotNet/test/RyftDotNet.Tests/assets/conversions/conversion-full.json
+++ b/RyftDotNet/test/RyftDotNet.Tests/assets/conversions/conversion-full.json
@@ -1,0 +1,32 @@
+{
+  "id": "con_01FCTS1XMKH9FF43CAFA4CXT3P",
+  "sell": {
+    "amount": 1000,
+    "currency": "GBP"
+  },
+  "buy": {
+    "amount": 1247,
+    "currency": "USD",
+    "fees": {
+      "ryft": {
+        "amount": 10
+      },
+      "platform": {
+        "amount": 5,
+        "ryftFee": {
+          "amount": 2
+        }
+      }
+    }
+  },
+  "rate": 1.247,
+  "status": 1,
+  "reason": "FX conversion",
+  "estimatedSettlementDate": "2024-03-15",
+  "settledTimestamp": 1470989600,
+  "createdBy": {
+    "id": "ac_b83f2653-06d7-44a9-a548-5825e8186004",
+    "name": "Test Account"
+  },
+  "createdTimestamp": 1470989538
+}

--- a/RyftDotNet/test/RyftDotNet.Tests/assets/conversions/conversion-full.json
+++ b/RyftDotNet/test/RyftDotNet.Tests/assets/conversions/conversion-full.json
@@ -20,7 +20,7 @@
     }
   },
   "rate": 1.247,
-  "status": 1,
+  "status": "Settled",
   "reason": "FX conversion",
   "estimatedSettlementDate": "2024-03-15",
   "settledTimestamp": 1470989600,

--- a/RyftDotNet/test/RyftDotNet.Tests/assets/conversions/conversion-min.json
+++ b/RyftDotNet/test/RyftDotNet.Tests/assets/conversions/conversion-min.json
@@ -6,6 +6,6 @@
   "buy": {
     "currency": "USD"
   },
-  "status": 0,
+  "status": "InProgress",
   "createdTimestamp": 1470989538
 }

--- a/RyftDotNet/test/RyftDotNet.Tests/assets/conversions/conversion-min.json
+++ b/RyftDotNet/test/RyftDotNet.Tests/assets/conversions/conversion-min.json
@@ -1,7 +1,6 @@
 {
   "id": "con_01FCTS1XMKH9FF43CAFA4CXT3P",
   "sell": {
-    "amount": 1000,
     "currency": "GBP"
   },
   "buy": {

--- a/RyftDotNet/test/RyftDotNet.Tests/assets/conversions/conversion-min.json
+++ b/RyftDotNet/test/RyftDotNet.Tests/assets/conversions/conversion-min.json
@@ -1,6 +1,7 @@
 {
   "id": "con_01FCTS1XMKH9FF43CAFA4CXT3P",
   "sell": {
+    "amount": 1000,
     "currency": "GBP"
   },
   "buy": {

--- a/RyftDotNet/test/RyftDotNet.Tests/assets/conversions/conversion-min.json
+++ b/RyftDotNet/test/RyftDotNet.Tests/assets/conversions/conversion-min.json
@@ -1,0 +1,11 @@
+{
+  "id": "con_01FCTS1XMKH9FF43CAFA4CXT3P",
+  "sell": {
+    "currency": "GBP"
+  },
+  "buy": {
+    "currency": "USD"
+  },
+  "status": 0,
+  "createdTimestamp": 1470989538
+}

--- a/RyftDotNet/test/RyftDotNet.Tests/assets/conversions/rate.json
+++ b/RyftDotNet/test/RyftDotNet.Tests/assets/conversions/rate.json
@@ -1,0 +1,23 @@
+{
+  "sell": {
+    "amount": 1000,
+    "currency": "GBP"
+  },
+  "buy": {
+    "amount": 1247,
+    "currency": "USD",
+    "fees": {
+      "ryft": {
+        "amount": 10
+      },
+      "platform": {
+        "amount": 5,
+        "ryftFee": {
+          "amount": 2
+        }
+      }
+    }
+  },
+  "rate": 1.247,
+  "estimatedSettlementDate": "2024-03-15"
+}

--- a/RyftDotNet/test/RyftDotNet.Tests/assets/conversions/rate.json
+++ b/RyftDotNet/test/RyftDotNet.Tests/assets/conversions/rate.json
@@ -1,7 +1,13 @@
 {
   "sell": {
     "amount": 1000,
-    "currency": "GBP"
+    "currency": "GBP",
+    "fees": {
+      "ryft": {
+        "amount": 8
+      },
+      "platform": null
+    }
   },
   "buy": {
     "amount": 1247,


### PR DESCRIPTION
## Summary
- Adds `IConversionApiClient`/`ConversionApiClient` covering the four public
  money-movement-service conversion endpoints:
  `POST /v1/conversions`, `GET /v1/conversions/{id}`, `GET /v1/conversions`,
  `GET /v1/conversions/rate`
- Adds request models (`CreateConversionRequest`, `ConversionSideRequest`,
  `ListConversionsRequest`, `GetRateRequest`) and response models
  (`Conversion`, `ConversionRate`, and their nested types)
- Wires `ListAsync`/`GetRates` to append query-string parameters
  (`limit`, `ascending`, `startsAfter`, `startTimestamp`, `endTimestamp`,
  `buyCurrency`, `sellCurrency`, `amount`) and corrects `GetRates` to take
  `GetRateRequest` instead of the unrelated `ListConversionsRequest`
- Adds unit test coverage for all four endpoints, including query-string
  propagation for `ListAsync` and `GetRates`
- Adds integration tests exercising create/get/list/rate against a live
  environment