### PR TITLE
Rp 1760/update nuget trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Package
         run: dotnet pack --no-build --configuration Release --output nuget
 
-      - name: NuGet Login
+      - name: NuGet Login (Trusted Publishing)
         uses: NuGet/login@v1
         id: login
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,12 @@
 name: publish-to-nuget
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Run the full pipeline but skip the actual push to nuget.org
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -42,4 +47,5 @@ jobs:
           user: ryftpay
       
       - name: Upload to Nuget
+        if: ${{ !inputs.dry_run }}
         run: dotnet nuget push nuget/*.nupkg --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --source "nuget.org" --skip-duplicate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
         uses: NuGet/login@v1
         id: login
         with:
-          user: ryft-ci
+          user: ryftpay
       
       - name: Upload to Nuget
         run: dotnet nuget push nuget/*.nupkg --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --source "nuget.org" --skip-duplicate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,13 +3,17 @@ name: publish-to-nuget
 on:
   workflow_dispatch: {}
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
         dotnet: ['8.0.x']
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -21,15 +25,21 @@ jobs:
 
       - name: Restore dependencies
         run: dotnet restore
-        
+
       - name: Build
         run: dotnet build -c Release
-        
+
       - name: Unit tests
         run: ./test.sh
 
       - name: Package
         run: dotnet pack --no-build --configuration Release --output nuget
 
+      - name: NuGet Login
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ryft-ci
+      
       - name: Upload to Nuget
-        run: dotnet nuget push nuget/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source "nuget.org" --skip-duplicate
+        run: dotnet nuget push nuget/*.nupkg --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --source "nuget.org" --skip-duplicate


### PR DESCRIPTION
## Summary
Switch `publish-to-nuget` from a static NuGet API key to NuGet's Trusted Publishing (OIDC) — removes the long-lived `NUGET_API_KEY` secret in favor of a short-lived key minted per run via `NuGet/login`.

## Changes
- Added `permissions: id-token: write` so the workflow can request a GitHub OIDC token
- Replaced `--api-key ${{ secrets.NUGET_API_KEY }}` with a `NuGet Login` step (`NuGet/login@v1`, `user: ryftpay`) that exchanges the OIDC token for a short-lived nuget.org API key
- Push step now uses that key; still targets `--source "nuget.org"` — no change to where the package publishes
- Once confirmed working, the old `NUGET_API_KEY` repo secret can be deleted
- Added a dry run option